### PR TITLE
TOOLS-2452 add Jenkinsfiles for final molybdenum jenkinsBuildHook repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-node_modules
-output
+/make_stamps
+/node_modules
+/tmp
+/bits
+/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/eng"]
+	path = deps/eng
+	url = https://github.com/joyent/eng.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,18 +27,8 @@ pipeline {
                 sh('''
 set -o errexit
 set -o pipefail
-<<<<<<< HEAD
-
-# Build a tar and push to updates.joyent.com
-make clean release
-ls -l output/ziploader-*
-updates-imgadm -i ~/.ssh/automation.id_rsa -u mg --channel="experimental" \
-    import -m output/*.manifest -f output/*.tgz
-
-# Add -ddd back in once that's fixed
-=======
+ENGBLD_BITS_UPLOAD_IMGAPI=true
 make all release publish bits-upload
->>>>>>> b1c0bbc... TOOLS-2452 add Jenkinsfiles for final molybdenum jenkinsBuildHook repos
 ''')
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                 sh('''
 set -o errexit
 set -o pipefail
-ENGBLD_BITS_UPLOAD_IMGAPI=true
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
 make all release publish bits-upload
 ''')
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+@Library('jenkins-joylib@v1.0.4') _
+
+pipeline {
+
+    agent {
+        label joyCommonLabels(image_ver: '15.4.1')
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+        timestamps()
+    }
+
+    stages {
+        stage('build image and upload') {
+            steps {
+                sh('''
+set -o errexit
+set -o pipefail
+<<<<<<< HEAD
+
+# Build a tar and push to updates.joyent.com
+make clean release
+ls -l output/ziploader-*
+updates-imgadm -i ~/.ssh/automation.id_rsa -u mg --channel="experimental" \
+    import -m output/*.manifest -f output/*.tgz
+
+# Add -ddd back in once that's fixed
+=======
+make all release publish bits-upload
+>>>>>>> b1c0bbc... TOOLS-2452 add Jenkinsfiles for final molybdenum jenkinsBuildHook repos
+''')
+            }
+        }
+    }
+
+    post {
+        always {
+            joyMattermostNotification()
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -5,52 +5,65 @@
 #
 
 #
-# Copyright (c) 2016, Joyent, Inc.
+# Copyright (c) 2020 Joyent, Inc.
 #
+
+ENGBLD_USE_BUILDIMAGE	= false
+ENGBLD_REQUIRE		:= $(shell git submodule update --init deps/eng)
+include ./deps/eng/tools/mk/Makefile.defs
+TOP ?= $(error Unable to access eng.git submodule Makefiles.)
+
+NAME 			= ziploader
+NODE_PREBUILT_TAG       = gz
+NODE_PREBUILT_VERSION	:= v0.10.48
+# sdc-minimal-multiarch-lts 15.4.1
+NODE_PREBUILT_IMAGE     = 18b094b0-eb01-11e5-80c1-175dac7ddf02
 
 TIMESTAMP := $(shell date -u "+%Y%m%dT%H%M%SZ")
 FILENAME := "ziploader-$(TIMESTAMP)"
 UUID := $(shell uuid -v 4)
 
-.PHONY: release
-release: tar manifest
+ifeq ($(shell uname -s),SunOS)
+        NODE_PREBUILT_TAG = gz
+        include ./deps/eng/tools/mk/Makefile.node_prebuilt.defs
+else
+        NODE := $(shell which node)
+        NPM := $(shell which npm)
+        NPM_EXEC=$(NPM)
+endif
+include ./deps/eng/tools/mk/Makefile.node_modules.defs
+
+.PHONY: all
+all: $(STAMP_NODE_MODULES)
 
 .PHONY: manifest
-manifest: output/$(FILENAME).tgz
-	@echo "=> building manifest (output/$(FILENAME).manifest"
-	@cat manifest.tmpl | sed \
+manifest: bits/$(NAME)/$(FILENAME).tgz
+	@echo "=> building manifest (bits/$(NAME)/$(FILENAME).manifest"
+	mkdir -p bits/$(NAME)
+	cat manifest.tmpl | sed \
         -e "s/{{BUILDSTAMP}}/$(TIMESTAMP)/g" \
-        -e "s/{{SHA1}}/$(shell sha1sum output/$(FILENAME).tgz | cut -d ' ' -f1)/g" \
-        -e "s/{{SIZE}}/$(shell stat -c '%s' output/$(FILENAME).tgz)/g" \
+        -e "s/{{SHA1}}/$(shell sha1sum bits/$(NAME)/$(FILENAME).tgz | cut -d ' ' -f1)/g" \
+        -e "s/{{SIZE}}/$(shell stat -c '%s' bits/$(NAME)/$(FILENAME).tgz)/g" \
         -e "s/{{UUID}}/$(UUID)/g" \
         -e "s/{{VERSION}}/$(TIMESTAMP)/g" \
-        > output/$(FILENAME).manifest
+        > bits/$(NAME)/$(FILENAME).manifest
 
-output/$(FILENAME).tgz: tar
+.PHONY:
+publish: bits/$(NAME)/$(FILENAME).tgz manifest
 
-.PHONY: tar
-tar: deps
-	@echo "=> building tar (output/$(FILENAME).tgz)"
-	@mkdir -p output
-	@tar -zcvf output/$(FILENAME).tgz \
-        *.js \
-        LICENSE \
-        node_modules \
-        package.json \
-        README.md
+bits/$(NAME)/$(FILENAME).tgz: all
+	@echo "=> building tar (bits/$(NAME)/$(FILENAME).tgz)"
+	mkdir -p bits/$(NAME)
+	tar -zcvf bits/$(NAME)/$(FILENAME).tgz \
+	    *.js \
+            LICENSE \
+            node_modules \
+            package.json \
+            README.md
 
-.PHONY: deps
-deps:
-	@mkdir -p node_modules
-	@echo "=> npm install"
-	@npm install
-	./node_modules/.bin/kthxbai || true # work around trentm/node-kthxbai#1
-	./node_modules/.bin/kthxbai
-
-.PHONY: clean
-clean:
-	@echo "=> cleaning"
-	@rm -rf output
-
-check:
+check::
 	jshint *.js
+
+include ./deps/eng/tools/mk/Makefile.node_prebuilt.targ
+include ./deps/eng/tools/mk/Makefile.node_modules.targ
+include ./deps/eng/tools/mk/Makefile.targ


### PR DESCRIPTION
This is more cleaning out of the stragglers from mo.joyent.com so that we can remove more of the hooks code from mo, and the freestyle jobs from Jenkins.

I'm not sure quite how to test this, but this build is creating the archive as expected and posting it to updates.joyent.com 

https://jenkins.joyent.us/job/joyent-org/job/ziploader/job/prr-TOOLS-2452/